### PR TITLE
Add em dash as alternative to decrease karma

### DIFF
--- a/src/pluspplus.coffee
+++ b/src/pluspplus.coffee
@@ -28,7 +28,7 @@ module.exports = (robot) ->
   scoreKeeper = new ScoreKeeper(robot)
 
   # sweet regex bro
-  robot.hear /^([\w\S']+)?(?:[\W\s]*)?(\+\+|\-\-)(?: (?:for|because|cause|cuz) (.+))?$/i, (msg) ->
+  robot.hear /^([\w\S']+)?(?:[\W\s]*)?(\+\+|\-\-|—)(?: (?:for|because|cause|cuz) (.+))?$/i, (msg) ->
     # let's get our local vars in place
     [__, name, operator, reason] = msg.match
     from = msg.message.user.name.toLowerCase()


### PR DESCRIPTION
As discussed in https://github.com/github/hubot-scripts/pull/1377.

---

> Some clients like [Slack](https://slack.com/) replace the `--` in
> 
> ```
> wellle-- for writing hubot scripts
> ```
> 
> to an Em dash `—`
> 
> ```
> wellle— for writing hubot scripts
> ```
> 
> which doesn't get recognized in Hubot's karma script.
> 
> This pull requests decreases karma in the example above by triggering `karma.decrement` on Em dashes too.
