### PR TITLE
added replace statement so @name is same as just name for +1/-1

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -45,7 +45,7 @@ module.exports = (robot) ->
 
     # do some sanitizing
     reason = reason?.trim().toLowerCase()
-    name = name?.trim().toLowerCase()
+    name = (name?.replace /^.*@/g, "").trim().toLowerCase()
 
     # check whether a name was specified. use MRU if not
     unless name?


### PR DESCRIPTION
When some one gives `++` to the default name format in hipchat `@name++` it adds karma to that string. So added a regex to remove the `@` that way `@name++` and `name++` should both get have the same score effects

Ref: https://github.com/github/hubot-scripts/pull/1440
