### PR TITLE
Fix some regex issues

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -46,7 +46,7 @@ module.exports = (robot) ->
 
     # do some sanitizing
     reason = reason?.trim().toLowerCase()
-    name = (name?.replace /(^\s*@)|([,:\s]*$)/g, "").trim().toLowerCase()
+    name = (name.replace /(^\s*@)|([,:\s]*$)/g, "").trim().toLowerCase() if name
 
     # check whether a name was specified. use MRU if not
     unless name?


### PR DESCRIPTION
Fixes a couple of problems with the regex matching and variable handling.
1. the expanded regex format consumes whitespace characters so the leading space before the reason-qualifier was disappearing. So to add a reason you had to do `foo++for blah` (no separating space)
2. The remove "@" prefix before names was being too greedy and removing _anything_ before an @ symbol, so `foo@bar++` would end up awarding points to 'bar'.
3. The case where only `++` was used was leading to name?.replace returning `Void` which doesn't have a `.trim()` method, so this command function was no longer working.
