### PR TITLE
Misc slack helps

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -33,7 +33,7 @@ module.exports = (robot) ->
     # from beginning of line
     ^
     # the thing being upvoted, which is any number of words and spaces
-    ([\s\w'@.-]*)
+    ([\s\w'@.-:]*)
     # the increment/decrement operator ++ or --
     ([-+]{2}|—)
     # optional reason for the plusplus

--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -34,6 +34,8 @@ module.exports = (robot) ->
     ^
     # the thing being upvoted, which is any number of words and spaces
     ([\s\w'@.-:]*)
+    # allow for spaces after the thing being upvoted (@user ++)
+    \s*
     # the increment/decrement operator ++ or --
     ([-+]{2}|—)
     # optional reason for the plusplus


### PR DESCRIPTION
Allows for slack mentions, which are by default formatted with a `: ` (colon and space) to be recognized as valid ++'s:

`@demo: ++ for things` will now work.

Fixes issue #31 