### PR TITLE
Place the scores endpoint under a "URLs" heading in the plugin documentation

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -14,7 +14,9 @@
 #   hubot top <amount>
 #   hubot bottom <amount>
 #   hubot erase <user> [<reason>]
-#   GET http://<url>/hubot/scores[?name=<name>][&direction=<top|botton>][&limit=<10>]
+#
+# URLs:
+#   /hubot/scores[?name=<name>][&direction=<top|botton>][&limit=<10>]
 #
 # Author:
 #   ajacksified


### PR DESCRIPTION
Document the scores endpoint by placing it under a "URLs" heading (following the pattern used in [hubot-help](https://github.com/hubot-scripts/hubot-help/blob/master/src/help.coffee#L8)) so that the `hubot help` command doesn't include the endpoint.