### PR TITLE
Bugfix: Missing colon in respond

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -91,7 +91,7 @@ module.exports = (robot) ->
   robot.respond ///
     (?:erase )
     # thing to be erased
-    ([\s\w'@.-]+?)
+    ([\s\w'@.-:]+?)
     # optionally erase a reason from thing
     (?:\s+(?:for|because|cause|cuz)\s+(.+))?
     $ # eol


### PR DESCRIPTION
Hi, This repo is feel great! XD

I found a bug. I cannot `erase xxx` if it includes `:`.

Please consider to merge this PR.