### PR TITLE
Add 'as' to the regex for catching reasons

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -41,7 +41,7 @@ module.exports = (robot) ->
     # the increment/decrement operator ++ or --
     (\+\+|--|—)
     # optional reason for the plusplus
-    (?:\s+(?:for|because|cause|cuz)\s+(.+))?
+    (?:\s+(?:for|because|cause|cuz|as)\s+(.+))?
     $ # end of line
   ///i, (msg) ->
     # let's get our local vars in place


### PR DESCRIPTION
This is for example to catch the following:

```
@johndoe: ++ as @radeksimko has learnt something new from him
```
