### PR TITLE
Documentation (help command) Fixes

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -8,12 +8,12 @@
 # Configuration:
 #
 # Commands:
-#   <name>++ increment score for a name
-#   <name>-- decrement score for a name
-#   hubot score <name> [for <reason>]
-#   hubot top <amount>
-#   hubot bottom <amount>
-#   hubot erase <name> [<reason>]
+#   <name>++ [<reason>] - Increment score for a name (for a reason)
+#   <name>-- [<reason>] - Decrement score for a name (for a reason)
+#   hubot score <name> - Display the score for a name and some of the reasons
+#   hubot top <amount> - Display the top scoring <amount>
+#   hubot bottom <amount> - Display the bottom scoring <amount>
+#   hubot erase <name> [<reason>] - Remove the score for a name (for a reason)
 #
 # URLs:
 #   /hubot/scores[?name=<name>][&direction=<top|botton>][&limit=<10>]

--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -8,12 +8,12 @@
 # Configuration:
 #
 # Commands:
-#   <name>++
-#   <name>--
+#   <name>++ - increment score for a name
+#   <name>-- - decrement score for a name
 #   hubot score <name> [for <reason>]
 #   hubot top <amount>
 #   hubot bottom <amount>
-#   hubot erase <user> [<reason>]
+#   hubot erase <name> [<reason>]
 #
 # URLs:
 #   /hubot/scores[?name=<name>][&direction=<top|botton>][&limit=<10>]

--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -8,8 +8,8 @@
 # Configuration:
 #
 # Commands:
-#   <name>++ - increment score for a name
-#   <name>-- - decrement score for a name
+#   <name>++ increment score for a name
+#   <name>-- decrement score for a name
 #   hubot score <name> [for <reason>]
 #   hubot top <amount>
 #   hubot bottom <amount>


### PR DESCRIPTION
A few small changes:

- add documentation for `<name>++` and `<name>--`
- change `erase` parameter to `name` for consistency
- unify all the help text