### PR TITLE
Bugfix: Use singular point when score is 1 or -1

### DIFF
--- a/src/plusplus.coffee
+++ b/src/plusplus.coffee
@@ -80,7 +80,10 @@ module.exports = (robot) ->
     if score?
       message = if reason?
                   if reasonScore == 1 or reasonScore == -1
-                    "#{name} has #{score} points, #{reasonScore} of which is for #{reason}."
+                    if score == 1 or score == -1
+                      "#{name} has #{score} point for #{reason}."
+                    else
+                      "#{name} has #{score} points, #{reasonScore} of which is for #{reason}."
                   else
                     "#{name} has #{score} points, #{reasonScore} of which are for #{reason}."
                 else


### PR DESCRIPTION
When reasonScore is 1 or -1 and score is 1 or -1, use singular "point" instead of "points" and remove unnecessary phrasing. 

So if ajacksified has 0 points then ajacksified++ for reviewing this pull request, the phrasing was:

"ajacksified has 1 points, one of which is for reviewing this pull request."

Now it is:

"ajacksified has 1 point for reviewing this pull request."